### PR TITLE
fix: _normalizeText removing @ from email keys

### DIFF
--- a/dist/lib/pix.js
+++ b/dist/lib/pix.js
@@ -96,7 +96,7 @@ var PIX = /** @class */ (function () {
     };
     PIX.prototype._normalizeText = function (value) {
         var str = value.toUpperCase().replace('Ç', 'C');
-        return str['normalize']("NFD").replace(/[^A-Z0-9$%*+-\./:]/gi, ' ');
+        return str['normalize']("NFD").replace(/[^A-Z0-9$@%*+-\./:]/gi, ' ');
     };
     PIX.prototype.getBRCode = function () {
         var lines = [];

--- a/lib/pix.ts
+++ b/lib/pix.ts
@@ -1,8 +1,8 @@
 import { CRC } from "./crc/crc";
 import { IDinamic } from "./idinamic";
 import { IStatic } from "./istatic";
-import * as qrcode from "qrcode"
-import * as fs from "fs"
+import * as qrcode from "qrcode";
+import * as fs from "fs";
 
 export class PIX implements IDinamic, IStatic {
 
@@ -79,7 +79,7 @@ export class PIX implements IDinamic, IStatic {
 
     private _normalizeText(value: string) {
         let str = value.toUpperCase().replace('Ç','C') as any
-        return str['normalize']("NFD").replace(/[^A-Z0-9$%*+-\./:]/gi, ' ')
+        return str['normalize']("NFD").replace(/[^A-Z0-9$@%*+-\./:]/gi, ' ')
     }
 
     getBRCode() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "sourceMap": true,
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "dist"
     ],
     "compilerOptions": {
         "target": "es5",


### PR DESCRIPTION
Adds `@` character on `_normalizeText()` function to allow email type keys