### PR TITLE
fix: normalizeText function removing underline from email type keys

### DIFF
--- a/dist/lib/pix.js
+++ b/dist/lib/pix.js
@@ -194,7 +194,7 @@ var PIX = /** @class */ (function () {
         });
     };
     PIX.prototype._normalizeText = function (value) {
-        return value.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^A-Z\[\]0-9$@%*+-\./:]/gi, ' ');
+        return value.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^A-Z\[\]0-9$@%*+-\./:_]/gi, ' ');
     };
     PIX.prototype._generateAccountInformation = function () {
         var payload = [];

--- a/lib/pix.ts
+++ b/lib/pix.ts
@@ -173,7 +173,7 @@ export class PIX implements IDinamic, IStatic {
 
 
     private _normalizeText(value: string) {
-        return value.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^A-Z\[\]0-9$@%*+-\./:]/gi, ' ')
+        return value.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^A-Z\[\]0-9$@%*+-\./:_]/gi, ' ')
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gpix",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Library written in nodejs to generate PIX br-code and qr-code.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Example to reproduce the situation: 
```js
let pix = PIX.static()
    .setReceiverName('Hiago Silva Souza')
    .setReceiverCity('Rio Preto')
    .setKey('hiago_me@hiago.me')
    .setDescription('Donation with defined amount - GPIX')
    .setReceiverZipCode('15082131')
    .setIdentificator('123')
    .setAmount(5.0)
```

Expected:
```
00020101021126780014br.gov.bcb.pix0117hiago_me@hiago.me0235Donation with defined amount - GPIX52040000530398654045.005802BR5917Hiago Silva Souza6009Rio Preto61081508213162070503123630450CE
```

Received:
```
00020101021126780014br.gov.bcb.pix0117hiago me@hiago.me0235Donation with defined amount - GPIX52040000530398654045.005802BR5917Hiago Silva Souza6009Rio Preto6108150821316207050312363048F67
```